### PR TITLE
Enable log tracking via Elasticsearch/Kibana

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,9 @@
+## Logging
+ELK_VERSION=7.14.1
+
+## VRT version
+VRT_VERSION=4.17.0
+
 ## Frontend
 
 # direct URL to backend with port (same as APP_PORT)

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Basic wrapper over API to be used for integration with existing tools
 * [Playwright](https://github.com/Visual-Regression-Tracker/Visual-Regression-Tracker/wiki/Getting-started-with-Playwright)
 * [Storybook](https://github.com/Visual-Regression-Tracker/Visual-Regression-Tracker/wiki/Storybook)
 * [Selenide (Java)](https://github.com/Visual-Regression-Tracker/Visual-Regression-Tracker/wiki/Getting-started-with-Selenide)
-* [Jenkins VRT result publising example (with JAVA SDK)](https://github.com/Visual-Regression-Tracker/Visual-Regression-Tracker/wiki/How-to-publish-VRT-result-in-jenkins)
+* [Jenkins VRT result publishing example (with JAVA SDK)](https://github.com/Visual-Regression-Tracker/Visual-Regression-Tracker/wiki/How-to-publish-VRT-result-in-jenkins)
 
 ## Integration examples
 Here you could find examples 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
-version: "2.1"
+version: '3.2'
+
 services:
   ui:
-    image: visualregressiontracker/ui:4.17.0
+    image: visualregressiontracker/ui:${VRT_VERSION}
     ports:
       - "${PORT}:8080"
     # https config
@@ -16,7 +17,7 @@ services:
       REACT_APP_API_URL: ${REACT_APP_API_URL}
     restart: always
   api:
-    image: visualregressiontracker/api:4.17.0
+    image: visualregressiontracker/api:${VRT_VERSION}
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       JWT_SECRET: ${JWT_SECRET}
@@ -34,7 +35,7 @@ services:
       - postgres
     restart: always
   migration:
-    image: visualregressiontracker/migration:4.17.0
+    image: visualregressiontracker/migration:${VRT_VERSION}
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
     depends_on:
@@ -59,3 +60,67 @@ services:
       interval: 10s
       timeout: 120s
       retries: 10
+
+  elasticsearch:
+    build:
+      context: elasticsearch/
+      args:
+        ELK_VERSION: $ELK_VERSION
+    volumes:
+      - type: bind
+        source: ./elasticsearch/config/elasticsearch.yml
+        target: /usr/share/elasticsearch/config/elasticsearch.yml
+        read_only: true
+      - type: volume
+        source: elasticsearch
+        target: /usr/share/elasticsearch/data
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    environment:
+      ES_JAVA_OPTS: "-Xmx256m -Xms256m"
+#      ELASTIC_PASSWORD: changeme
+      # Use single node discovery in order to disable production mode and avoid bootstrap checks.
+      # see: https://www.elastic.co/guide/en/elasticsearch/reference/current/bootstrap-checks.html
+      discovery.type: single-node
+    networks:
+      - elk
+
+  kibana:
+    build:
+      context: kibana/
+      args:
+        ELK_VERSION: $ELK_VERSION
+    volumes:
+      - type: bind
+        source: ./kibana/config/kibana.yml
+        target: /usr/share/kibana/config/kibana.yml
+        read_only: true
+    ports:
+      - "5601:5601"
+    networks:
+      - elk
+    depends_on:
+      - elasticsearch
+
+  filebeat:
+    build:
+      context: filebeat/
+      args:
+        ELK_VERSION: $ELK_VERSION
+    user: root
+    volumes:
+      - ./filebeat/config/filebeat.yml:/usr/share/filebeat/filebeat.yml:ro
+      - /var/lib/docker:/var/lib/docker:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - elk
+    depends_on:
+      - kibana
+
+networks:
+  elk:
+    driver: bridge
+
+volumes:
+  elasticsearch:

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,0 +1,7 @@
+ARG ELK_VERSION
+
+# https://www.docker.elastic.co/
+FROM docker.elastic.co/elasticsearch/elasticsearch:${ELK_VERSION}
+
+# Add your elasticsearch plugins setup here
+# Example: RUN elasticsearch-plugin install analysis-icu

--- a/elasticsearch/config/elasticsearch.yml
+++ b/elasticsearch/config/elasticsearch.yml
@@ -1,0 +1,13 @@
+---
+## Default Elasticsearch configuration from Elasticsearch base image.
+## https://github.com/elastic/elasticsearch/blob/master/distribution/docker/src/docker/config/elasticsearch.yml
+#
+cluster.name: "docker-cluster"
+network.host: 0.0.0.0
+
+## X-Pack settings
+## see https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-xpack.html
+#
+#xpack.license.self_generated.type: basic
+#xpack.security.enabled: true
+#xpack.monitoring.collection.enabled: true

--- a/filebeat/Dockerfile
+++ b/filebeat/Dockerfile
@@ -1,0 +1,3 @@
+ARG ELK_VERSION
+
+FROM docker.elastic.co/beats/filebeat:${ELK_VERSION}

--- a/filebeat/config/filebeat.yml
+++ b/filebeat/config/filebeat.yml
@@ -1,0 +1,61 @@
+filebeat.inputs:
+- type: container
+  paths:
+    - '/var/lib/docker/containers/*/*.log'
+    - '~/Library/Containers/com.docker.docker/Data/*/*.log'
+  multiline:
+    pattern: '^[[:space:]]+(at|\.{3})\b|^Caused by:'
+    match: after
+    negate: false
+
+processors:
+- add_docker_metadata:
+    host: "unix:///var/run/docker.sock"
+
+- decode_json_fields:
+    fields: ["message"]
+    target: "json"
+    overwrite_keys: true
+
+- drop_event:
+    when:
+      not:
+        or:
+          - contains:
+              container.image.name: "visualregressiontracker/ui"
+          - contains:
+              container.image.name: "visualregressiontracker/api"
+          - contains:
+              container.image.name: "postgres"
+          - contains:
+              container.image.name: "visualregressiontracker/migration"
+
+- dissect:
+    when:
+      contains:
+        message: "VRTUserLogService"
+    tokenizer: '%{vrtPrependValue}VRTUserLogService] %{vrtEventType} ## %{vrtUser} ## %{vrtMessage}'
+    target_prefix: ""
+    ignore_failure: true
+
+output.elasticsearch:
+  hosts: ["elasticsearch:9200"]
+  indices:
+    - index: "vrt-user-log"
+      when.contains:
+        message: "VRTUserLogService"
+    - index: "vrt-ui"
+      when.contains:
+        container.image.name: "visualregressiontracker/ui"
+    - index: "vrt-api"
+      when.contains:
+        container.image.name: "visualregressiontracker/api"
+    - index: "vrt-postgres"
+      when.contains:
+        container.image.name: "postgres"
+    - index: "vrt-migration"
+      when.contains:
+        container.image.name: "visualregressiontracker/migration"
+
+logging.json: true
+logging.metrics.enabled: false

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -1,0 +1,7 @@
+ARG ELK_VERSION
+
+# https://www.docker.elastic.co/
+FROM docker.elastic.co/kibana/kibana:${ELK_VERSION}
+
+# Add your kibana plugins setup here
+# Example: RUN kibana-plugin install <name|url>

--- a/kibana/config/kibana.yml
+++ b/kibana/config/kibana.yml
@@ -1,0 +1,13 @@
+---
+## Default Kibana configuration from Kibana base image.
+## https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/templates/kibana_yml.template.ts
+#
+server.name: kibana
+server.host: 0.0.0.0
+elasticsearch.hosts: [ "http://elasticsearch:9200" ]
+monitoring.ui.container.elasticsearch.enabled: true
+
+## X-Pack security credentials
+#
+#elasticsearch.username: elastic
+#elasticsearch.password: changeme


### PR DESCRIPTION
Elastic stack implementation. This has been tested in MacOS and CentOS systems. Multiple indexes from the docker logs are created from which dashboards can be created as needed. Because we are pulling down a few more docker containers to implement elastic stack, it will consume a little more CPU/memory. The stack uses Kibana+Elasticsearch+Filebeat. Below are sample dashboard and index. This will form base for issue https://github.com/Visual-Regression-Tracker/Visual-Regression-Tracker/issues/206 
<img width="1428" alt="KibanaDashboard" src="https://user-images.githubusercontent.com/9042580/133873540-4c8c6809-16a5-4bf0-b348-a64e95973354.png">
<img width="1157" alt="KibanaIndex" src="https://user-images.githubusercontent.com/9042580/133873541-171e5c8a-a5bb-489d-92df-7d55b5886156.png">
s.