### PR TITLE
Fix JWT issue on OSX Monterey

### DIFF
--- a/vrt-install.sh
+++ b/vrt-install.sh
@@ -10,7 +10,7 @@ ENV_FILE=.env
 REACT_APP_API_URL=
 APP_FRONTEND_URL=
 POSTGRES_FOLDER=
-JWT_SECRET=`cat /dev/urandom | env LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1`
+JWT_SECRET=`cat /dev/urandom | env LC_CTYPE=en.US.UTF-8 tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1`
 
 usage()
 {


### PR DESCRIPTION
This fixes [Issue#347](https://github.com/Visual-Regression-Tracker/Visual-Regression-Tracker/issues/347)

Solution was taken from https://stackoverflow.com/questions/70550078/has-anything-changed-with-dev-urandom-on-macos-monterey

Before Fix on OSX Montery
==========================
```
$ ~/vrt  uname -a
Darwin xxxxx.local 21.3.0 Darwin Kernel Version 21.3.0: Wed Jan  5 21:37:58 PST 2022; root:xnu-8019.80.24~20/RELEASE_X86_64 x86_64
$ ~/vrt  cat /dev/urandom | env LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1
Input error
$ ~/vrt 
```
After fix 
==========




On Mac OSX Monterey
===================
```
bash-3.2$ uname -a
Darwin xxxxxxa.local 21.3.0 Darwin Kernel Version 21.3.0: Wed Jan  5 21:37:58 PST 2022; root:xnu-8019.80.24~20/RELEASE_X86_64 x86_64
bash-3.2$
bash-3.2$ cat /dev/urandom | env LC_CTYPE=en.US.UTF-8 tr -dc 'a-zA-Z0-9' | fold -w 40 | head -n1
jjIlsoOF9tg0sOstkpXooBzojxGKYYWlrs4rDKDQ
bash-3.2$
```



On Linux
========
```
[tchia@ip-172-16-51-137 ~]$ cat /dev/urandom | env LC_CTYPE=en.US.UTF-8 tr -dc 'a-zA-Z0-9' | fold -w 40 | head -n1
YLAKPi9ASsVaSTSKvFwEwnBg1dSFvqqgUpzpwX6w
[tchia@ip-172-16-51-137 ~]$ uname -a
Linux ip-172-16-51-137 4.14.26-46.32.amzn1.x86_64 #1 SMP Fri Mar 30 22:29:54 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
[tchia@ip-172-16-51-137 ~]$
```